### PR TITLE
use canonical code version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+bin/parser-modified
+results.*
+logs.ldjson

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build: 
+	go build -o bin/parser-modified ./internal/parser/main.go
+
+compare: build 
+	hyperfine --warmup 1 --runs 10 --export-markdown results.md --export-json results.json \
+	"bin/parser-control < logs.ldjson" \
+	"bin/parser-modified < logs.ldjson"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Generator and Parser for ldjson file
 
+## Install hyperfine
+Install [hyperfine](https://github.com/sharkdp/hyperfine) to compare parsing speed.
+
+
 ## For generating ldjson file
 
 ```

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -5,13 +5,12 @@ import (
 	parser "GeneratorAndParser/internal/parser/handlers"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 	"time"
 )
 
-var levels = []string{"trace", "debug", "info", "warn", "error"}
+var levels = []parser.LogLevel{"trace", "debug", "info", "warn", "error"}
 
 var (
 	n int
@@ -24,12 +23,6 @@ func init() {
 func main() {
 	flag.Parse()
 
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("Recovered from panic: %v", r)
-		}
-	}()
-
 	startTime := time.Now()
 
 	ctx := handlers.SetupContext()
@@ -38,6 +31,7 @@ func main() {
 
 	if err != nil {
 		fmt.Printf("Error: %v", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("Log's level statistics:")


### PR DESCRIPTION
- Убрал string(LogLevel), сделал мапы `map[LogLevel]...`
- Убрал waitAndClose, в основном юзают анонимную горутину для этого

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bin/parser-control < logs.ldjson` | 79.5 ± 10.4 | 72.7 | 108.7 | 1.05 ± 0.14 |
| `bin/parser-modified < logs.ldjson` | 75.7 ± 1.5 | 73.7 | 78.6 | 1.00 |

Модифицированная версия показывает -3-5%. 